### PR TITLE
link to pthread on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,7 @@ add_executable(Carabiner
 
 target_link_libraries(Carabiner Ableton::Link gflags)
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  target_link_libraries(Carabiner pthread)
+endif()
+


### PR DESCRIPTION
Carabiner was failing to build on Linux, because of missing pthread linking, e.g:
`undefined reference to 'pthread_create'`
Adding `target_link_libraries(Carabiner pthread)` to CMakeLists.txt  fixes that.
