### PR TITLE
fix a memory issue, preventing Carabiner to work on Linux64

### DIFF
--- a/carabiner.cpp
+++ b/carabiner.cpp
@@ -305,10 +305,10 @@ int main(int argc, char* argv[]) {
   linkInstance.enable(true);
 
   struct mg_mgr mgr;
-  const char *port = ("tcp://127.0.0.1:" + std::to_string(FLAGS_port)).c_str();
+  std::string port = "tcp://127.0.0.1:" + std::to_string(FLAGS_port);
 
   mg_mgr_init(&mgr, NULL);
-  mg_bind(&mgr, port, eventHandler);
+  mg_bind(&mgr, port.c_str(), eventHandler);
 
   std::cout << "Starting Carabiner on port " << port << std::endl;
 


### PR DESCRIPTION
c_str() method was called on a temporary std::string (the addition of 2 strings), so "port" was no more
valid after the call.